### PR TITLE
PR 리뷰어 자동 할당

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @YuSangSeo @HoSeong0731 @chb09876 @kwYoohae @JeonHyerim86 @jiione @JinSeoHan @redman1234321
+


### PR DESCRIPTION
`.github/CODEOWNERS` 파일을 추가하여 백엔드 팀원모두 리뷰어로 들어가는 것으로 설정해놓았습니다.