### PR TITLE
[hotfix / #14] 전날 수익금 컬럼 추가

### DIFF
--- a/src/main/java/com/AiFunding/ToBi/entity/AccountEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/AccountEntity.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
+import javax.persistence.criteria.CriteriaBuilder;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -31,6 +32,9 @@ public class AccountEntity implements Serializable {
 
     @Column
     private Integer income;
+
+    @Column(name = "yesterday_income")
+    private Integer yesterdayIncome;
 
     @CreatedDate // 자동으로 생성된 날짜가 들어가게 함
     @Column(name = "create_at")


### PR DESCRIPTION
전날 수익금 컬럼이 급하게 추가되었습니다. 

이전 수익금을 기억하고 있어야 금일 수익금을 계산할 수 있습니다.