### PR TITLE
hotifx/[추가] Timestamp 추가

### DIFF
--- a/src/main/java/com/AiFunding/ToBi/entity/BaseCreateEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/BaseCreateEntity.java
@@ -1,13 +1,12 @@
 package com.AiFunding.ToBi.entity;
 
 import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,7 +15,7 @@ import java.time.LocalDateTime;
 public abstract class BaseCreateEntity {
 
     @CreatedDate
-    @Column(name = "create_at")
+    @Column(name = "create_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createAt;
 
 }

--- a/src/main/java/com/AiFunding/ToBi/entity/BaseCreateModifiedEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/BaseCreateModifiedEntity.java
@@ -1,13 +1,13 @@
 package com.AiFunding.ToBi.entity;
 
 import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,10 +16,10 @@ import java.time.LocalDateTime;
 public abstract class BaseCreateModifiedEntity {
 
     @CreatedDate
-    @Column(name = "create_at")
+    @Column(name = "create_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createAt;
 
     @LastModifiedDate
-    @Column(name = "modified_at")
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime modifiedAt;
 }


### PR DESCRIPTION
python에서 크롤링한 데이터를 넣을 경우 `craete_at` 과 `modified_at` 을 자동으로 `now()`로 넣게 하기 위해서

`Timestamp` 를 각각 컬럼에 추가하였습니다. 