### PR TITLE
hotfix/[추가] db 환경변수 추가

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-spring.profiles.include=oauth
+spring.profiles.include=oauth,real-db
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
+spring.session.store-type=jdbc


### PR DESCRIPTION
배포할 때 보다 편리하게 DB 정보를 사용하기 위해서 환경변수를 사용할 수 있는 셋팅을 해놓았습니다. 

기존에는 `application.properties` 안에 DB정보를 수동으로 계속 넣어주어서 파일을 수정했다고 `git pull`도 되지않아서 

따로 `db`만 담는 파일을 분리해서 얻는 형식으로 변경하였습니다. 