### PR TITLE
Featrue/#41 db에시그널저장

### DIFF
--- a/src/main/java/com/AiFunding/ToBi/controller/TradeSignalController.java
+++ b/src/main/java/com/AiFunding/ToBi/controller/TradeSignalController.java
@@ -1,0 +1,19 @@
+package com.AiFunding.ToBi.controller;
+
+import com.AiFunding.ToBi.dto.trade.signal.TradeSignalRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TradeSignalController {
+
+    @PostMapping("/signal")
+    public ResponseEntity<TradeSignalRequestDto> getSignal(@RequestBody TradeSignalRequestDto trade){
+
+        return ResponseEntity.ok().body(trade);
+    }
+}

--- a/src/main/java/com/AiFunding/ToBi/dto/trade/signal/TradeSignalDetailDto.java
+++ b/src/main/java/com/AiFunding/ToBi/dto/trade/signal/TradeSignalDetailDto.java
@@ -11,9 +11,12 @@ public class TradeSignalDetailDto {
 
     private Integer tradeSignal;
 
-    private Integer tradeAmount;
+    private Double tradeAmount;
 
-    TradeSignalDetailDto(final String stockName, final Integer tradeSignal, final Integer tradeAmount){
+    private String tradeModel;
+
+    TradeSignalDetailDto(final String stockName, final Integer tradeSignal, final Double tradeAmount,
+                         final String tradeModel){
         this.stockName = stockName;
         this.tradeAmount = tradeAmount;
         this.tradeSignal = tradeSignal;

--- a/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
@@ -2,10 +2,7 @@ package com.AiFunding.ToBi.entity;
 
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity // Jpa를 사용하기 위한 Entity 설정
 @NoArgsConstructor // 파라미터가 없는 생성자 생성
@@ -18,6 +15,7 @@ public class TradeSignalEntity extends BaseCreateEntity{
 
     @Id
     @Column(name = "trade_signal_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "stock_name")

--- a/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
@@ -28,5 +28,5 @@ public class TradeSignalEntity extends BaseCreateEntity{
     private String tradeModel;
 
     @Column(name = "trade_amount")
-    private String tradeAmount;
+    private Double tradeAmount;
 }

--- a/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/TradeSignalEntity.java
@@ -1,0 +1,34 @@
+package com.AiFunding.ToBi.entity;
+
+import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity // Jpa를 사용하기 위한 Entity 설정
+@NoArgsConstructor // 파라미터가 없는 생성자 생성
+@AllArgsConstructor // 모든 파라미터가 있는 생성자 생성
+@Builder // 빌더 패턴 사용
+@ToString // ToString 오버라이딩
+@Getter // Getter 사용
+@Table(name = "TRADE_SIGNAL") // SUBSCRIBE_INFO라는 이름의 테이블을 매핑해줍니다.
+public class TradeSignalEntity extends BaseCreateEntity{
+
+    @Id
+    @Column(name = "trade_signal_id")
+    private Long id;
+
+    @Column(name = "stock_name")
+    private String stockName;
+
+    @Column(name = "trade_signal")
+    private Integer tradeSignal;
+
+    @Column(name = "trade_model")
+    private String tradeModel;
+
+    @Column(name = "trade_amount")
+    private String tradeAmount;
+}

--- a/src/main/java/com/AiFunding/ToBi/mapper/TradeSignalRepository.java
+++ b/src/main/java/com/AiFunding/ToBi/mapper/TradeSignalRepository.java
@@ -1,0 +1,12 @@
+package com.AiFunding.ToBi.mapper;
+
+import com.AiFunding.ToBi.entity.TradeSignalEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface TradeSignalRepository extends JpaRepository<TradeSignalEntity, Long> {
+
+    List<TradeSignalEntity> findByCreateAtBetween(LocalDateTime startTime, LocalDateTime endTime);
+}

--- a/src/main/java/com/AiFunding/ToBi/mapper/TradingDetailRepository.java
+++ b/src/main/java/com/AiFunding/ToBi/mapper/TradingDetailRepository.java
@@ -1,7 +1,8 @@
 package com.AiFunding.ToBi.mapper;
 
+import com.AiFunding.ToBi.entity.TradeSignalEntity;
 import com.AiFunding.ToBi.entity.TradingDetailEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TradingDetailRepository extends JpaRepository<TradingDetailEntity,Long> {
+public interface TradingDetailRepository extends JpaRepository<TradeSignalEntity,Long> {
 }

--- a/src/test/java/com/AiFunding/ToBi/entity/TradeTest.java
+++ b/src/test/java/com/AiFunding/ToBi/entity/TradeTest.java
@@ -1,0 +1,39 @@
+package com.AiFunding.ToBi.entity;
+
+import com.AiFunding.ToBi.mapper.TradingDetailRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+@SpringBootTest
+public class TradeTest {
+
+    @Autowired
+    private TradingDetailRepository tradingDetailRepository;
+
+    @AfterEach
+    public void afterEach(){
+        tradingDetailRepository.deleteAll();
+    }
+
+    @Test
+    public void saveTest(){
+        TradeSignalEntity newData = TradeSignalEntity.builder()
+                .tradeAmount(3.33)
+                .tradeModel("HDL")
+                .stockName("삼성전자")
+                .tradeSignal(0)
+                .build();
+        tradingDetailRepository.save(newData);
+
+        Optional<TradeSignalEntity> findData = tradingDetailRepository.findById(1L);
+        Assertions.assertThat(newData.getTradeAmount()).isEqualTo(3.33);
+        Assertions.assertThat(newData.getTradeModel()).isEqualTo("HDL");
+        Assertions.assertThat(newData.getStockName()).isEqualTo("삼성전자");
+        Assertions.assertThat(newData.getTradeSignal()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### 작업내용
---
원래 DB에 Signal을 저장하는 작업을 안하려고 했는데 Batch때 불러오기 쉽고 이전 기록에서 디버그하기도 쉽게 하기 위해서 DB에 저장하려고합니다. 

그래서 TradeSignal에 대한 Entity를 생성했습니다. 

또한, `tradeModel` 에 대해서 판별이 기존에는 어려워서 `Json`에 추가하였습니다. 
### 주의사항
---
Test에서 `deleteAll()` 하므로 배포에 주의