### PR TITLE
Feature/#63수익비교탭구현

### DIFF
--- a/src/main/java/com/AiFunding/ToBi/controller/ProfitCompareController.java
+++ b/src/main/java/com/AiFunding/ToBi/controller/ProfitCompareController.java
@@ -1,0 +1,25 @@
+package com.AiFunding.ToBi.controller;
+
+import com.AiFunding.ToBi.dto.Home.UserRequestDto;
+import com.AiFunding.ToBi.dto.profit.ProfitAccountListDto;
+import com.AiFunding.ToBi.service.profit.ProfitCompareService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profit-compare")
+public class ProfitCompareController {
+    private final ProfitCompareService profitCompareService;
+
+    public ProfitCompareController(ProfitCompareService profitCompareService) {
+        this.profitCompareService = profitCompareService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProfitAccountListDto> profitAccountInfo(@RequestBody UserRequestDto userRequestDto) {
+        return ResponseEntity.ok().body(profitCompareService.findUserProfit(userRequestDto.getId(), userRequestDto.getLoginType()));
+    }
+}

--- a/src/main/java/com/AiFunding/ToBi/dto/profit/AccumulatedProfitResponseDto.java
+++ b/src/main/java/com/AiFunding/ToBi/dto/profit/AccumulatedProfitResponseDto.java
@@ -1,0 +1,22 @@
+package com.AiFunding.ToBi.dto.profit;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class AccumulatedProfitResponseDto {
+    //누적수익률 날짜
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime date;
+    //누적수익률
+    private Double profit;
+
+    public AccumulatedProfitResponseDto(final LocalDateTime date, final Double profit) {
+        this.date = date;
+        this.profit = profit;
+    }
+}

--- a/src/main/java/com/AiFunding/ToBi/dto/profit/ProfitAccountInfoResponseDto.java
+++ b/src/main/java/com/AiFunding/ToBi/dto/profit/ProfitAccountInfoResponseDto.java
@@ -1,0 +1,31 @@
+package com.AiFunding.ToBi.dto.profit;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ProfitAccountInfoResponseDto {
+    //ai번호
+    private Integer aiType;
+    //계좌이름
+    private String nickname;
+    //계좌번호
+    private String accountNumber;
+    //일별 누적수익률 리스트
+    private List<AccumulatedProfitResponseDto> profits;
+
+    public ProfitAccountInfoResponseDto(
+            final Integer aiType,
+            final String nickname,
+            final String accountNumber,
+            final List<AccumulatedProfitResponseDto> profits){
+        this.aiType = aiType;
+        this.nickname = nickname;
+        this.accountNumber = accountNumber;
+        this.profits = profits;
+    }
+
+}

--- a/src/main/java/com/AiFunding/ToBi/dto/profit/ProfitAccountListDto.java
+++ b/src/main/java/com/AiFunding/ToBi/dto/profit/ProfitAccountListDto.java
@@ -1,0 +1,17 @@
+package com.AiFunding.ToBi.dto.profit;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ProfitAccountListDto {
+    //계좌별 누적수익률 정보 리스트
+    private List<ProfitAccountInfoResponseDto> accounts;
+
+    public ProfitAccountListDto(final List<ProfitAccountInfoResponseDto> accounts) {
+        this.accounts = accounts;
+    }
+}

--- a/src/main/java/com/AiFunding/ToBi/entity/AccountEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/AccountEntity.java
@@ -2,14 +2,9 @@ package com.AiFunding.ToBi.entity;
 
 import com.sun.istack.NotNull;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
-import javax.persistence.criteria.CriteriaBuilder;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/AiFunding/ToBi/entity/TradingDetailEntity.java
+++ b/src/main/java/com/AiFunding/ToBi/entity/TradingDetailEntity.java
@@ -2,11 +2,9 @@ package com.AiFunding.ToBi.entity;
 
 import com.sun.istack.NotNull;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 @Entity // Jpa를 사용하기 위한 Entity 설정
 @NoArgsConstructor // 파라미터가 없는 생성자 생성

--- a/src/main/java/com/AiFunding/ToBi/mapper/CustomerInformationRepository.java
+++ b/src/main/java/com/AiFunding/ToBi/mapper/CustomerInformationRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface CustomerInformationRepository extends JpaRepository<CustomerInformationEntity,Long> {
     // user_sequence와 login_type을 통한 유저 정보 찾기
 //    @Query(value = "SELECT * FROM CUST_INFO CUST_INFO WHERE user_sequence=?0 AND login_type=?1", nativeQuery = true)
-    CustomerInformationEntity findByIdAndLoginType(Long id, String loginType);
+    Optional<CustomerInformationEntity> findByIdAndLoginType(Long id, String loginType);
 
     Optional<CustomerInformationEntity> findByIdAndLoginType(String id, String loginType);
     boolean existsByEmail(String email);

--- a/src/main/java/com/AiFunding/ToBi/mapper/TradingDetailRepository.java
+++ b/src/main/java/com/AiFunding/ToBi/mapper/TradingDetailRepository.java
@@ -1,7 +1,6 @@
 package com.AiFunding.ToBi.mapper;
 
 import com.AiFunding.ToBi.entity.TradeSignalEntity;
-import com.AiFunding.ToBi.entity.TradingDetailEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradingDetailRepository extends JpaRepository<TradeSignalEntity,Long> {

--- a/src/main/java/com/AiFunding/ToBi/service/ai/history/HistoryService.java
+++ b/src/main/java/com/AiFunding/ToBi/service/ai/history/HistoryService.java
@@ -9,10 +9,7 @@ import com.AiFunding.ToBi.entity.TradingDetailEntity;
 import com.AiFunding.ToBi.mapper.CustomerInformationRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class HistoryService {
@@ -25,9 +22,10 @@ public class HistoryService {
 
     // User 정보를 찾고 거래 내역 DTO 를 반환
     public AccountTradeHistoryResponseDto findUserHistory(final Long id, final String loginType) {
-        CustomerInformationEntity customerInfo = customerInformationRepository.findByIdAndLoginType(id, loginType);
+        Optional<CustomerInformationEntity> customerInfo = customerInformationRepository.findByIdAndLoginType(id, loginType);
+        customerInfo.orElseThrow(NullPointerException::new);
 
-        return new AccountTradeHistoryResponseDto(getAccountHistoryDtoList(customerInfo.getAccounts()));
+        return new AccountTradeHistoryResponseDto(getAccountHistoryDtoList(customerInfo.get().getAccounts()));
     }
 
     // 거래내역 관련 데이터 리스트 반환

--- a/src/main/java/com/AiFunding/ToBi/service/ai/page/AiService.java
+++ b/src/main/java/com/AiFunding/ToBi/service/ai/page/AiService.java
@@ -17,10 +17,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class AiService {
@@ -41,9 +38,9 @@ public class AiService {
 
     //id와 loginType을 가지는 Entitiy를 찾아서 DTO에 담고 반환
     public AiResponseDto findUserInfo(final Long id, final String loginType) {
-        CustomerInformationEntity customerInfo = customerInformationRepository.findByIdAndLoginType(id, loginType);//customerinformation
-
-        return new AiResponseDto(new CurrStockItemsResponseDto(getAccountDtoList(customerInfo.getAccounts())), new AccountTradeHistoryResponseDto(getAccountHistoryDtoList(customerInfo.getAccounts())));//CurrStockItemsResponseDto(getAccountDtoList(customerInfo.getAccounts()));
+        Optional<CustomerInformationEntity> customerInfo = customerInformationRepository.findByIdAndLoginType(id, loginType);//customerinformation
+        customerInfo.orElseThrow(NullPointerException::new);
+        return new AiResponseDto(new CurrStockItemsResponseDto(getAccountDtoList(customerInfo.get().getAccounts())), new AccountTradeHistoryResponseDto(getAccountHistoryDtoList(customerInfo.get().getAccounts())));//CurrStockItemsResponseDto(getAccountDtoList(customerInfo.getAccounts()));
     }
 
     //계좌이름과 보유주식리스트를 계좌DTO에 담아서  반환

--- a/src/main/java/com/AiFunding/ToBi/service/home/HomeService.java
+++ b/src/main/java/com/AiFunding/ToBi/service/home/HomeService.java
@@ -9,10 +9,7 @@ import com.AiFunding.ToBi.entity.CustomerInformationEntity;
 import com.AiFunding.ToBi.mapper.CustomerInformationRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class HomeService {
@@ -29,9 +26,9 @@ public class HomeService {
 
 
     public UserResponseDto findUserInfo(final Long id, final String loginType){
-        CustomerInformationEntity customer = customerInformationRepository.findByIdAndLoginType(id,loginType);
-
-        return new UserResponseDto(customer.getNickname(),getAccountData(customer.getAccounts()));
+        Optional<CustomerInformationEntity> customer = customerInformationRepository.findByIdAndLoginType(id,loginType);
+        customer.orElseThrow(NullPointerException::new);
+        return new UserResponseDto(customer.get().getNickname(),getAccountData(customer.get().getAccounts()));
 
     }
 

--- a/src/main/java/com/AiFunding/ToBi/service/profit/ProfitCompareService.java
+++ b/src/main/java/com/AiFunding/ToBi/service/profit/ProfitCompareService.java
@@ -60,7 +60,7 @@ public class ProfitCompareService {
     }
 
     /**
-     * @return 일별 누적수익률 리스트를 반환 -> 오늘총 수익금 / 어제의 총평가 금액 * 100
+     * @return 일별 누적수익률 리스트를 반환
      */
     public List<AccumulatedProfitResponseDto> getAccumulatedProfitResponseDtoList(AccountEntity accountEntity) {
         List<AccumulatedProfitResponseDto> accumulatedProfitResponseDtoList = new ArrayList<>();

--- a/src/main/java/com/AiFunding/ToBi/service/profit/ProfitCompareService.java
+++ b/src/main/java/com/AiFunding/ToBi/service/profit/ProfitCompareService.java
@@ -1,0 +1,136 @@
+package com.AiFunding.ToBi.service.profit;
+
+import com.AiFunding.ToBi.dto.profit.AccumulatedProfitResponseDto;
+import com.AiFunding.ToBi.dto.profit.ProfitAccountInfoResponseDto;
+import com.AiFunding.ToBi.dto.profit.ProfitAccountListDto;
+import com.AiFunding.ToBi.entity.AccountEntity;
+import com.AiFunding.ToBi.entity.AccountStockDetailEntity;
+import com.AiFunding.ToBi.entity.CustomerInformationEntity;
+import com.AiFunding.ToBi.entity.TradingDetailEntity;
+import com.AiFunding.ToBi.mapper.AccountStockDetailRepository;
+import com.AiFunding.ToBi.mapper.CustomerInformationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProfitCompareService {
+    private final CustomerInformationRepository customerInformationRepository;//사용자 정보 Repository
+    private final AccountStockDetailRepository accountStockDetailRepository;//계좌의 주식 상세 정보 Repository
+
+    public ProfitCompareService(CustomerInformationRepository customerInformationRepository, AccountStockDetailRepository accountStockDetailRepository) {
+        this.customerInformationRepository = customerInformationRepository;
+        this.accountStockDetailRepository = accountStockDetailRepository;
+    }
+
+    /**
+     * @param id
+     * @param loginType
+     * @return 해당 사용자의 수익 정보를 찾아서 반환함
+     */
+    public ProfitAccountListDto findUserProfit(final Long id, final String loginType) {
+        Optional<CustomerInformationEntity> customerInfo = customerInformationRepository.findByIdAndLoginType(id, loginType);
+        customerInfo.orElseThrow();
+        return new ProfitAccountListDto(getProfitAccountInfoResponseDtoList(customerInfo.get()));
+    }
+
+    /**
+     * @param customerInfo
+     * @return 사용자가 가지고 있는 모든 계좌의 수익정보를 list로 반환
+     */
+    public List<ProfitAccountInfoResponseDto> getProfitAccountInfoResponseDtoList(CustomerInformationEntity customerInfo) {
+        List<ProfitAccountInfoResponseDto> profitAccountInfoResponseDtoList = new ArrayList<>();
+        for (AccountEntity accountEntity : customerInfo.getAccounts()) {
+            //ai번호
+            Integer aiType =  accountEntity.getAiType();
+            //계좌이름
+            String nickname = accountEntity.getNickname();
+            //계좌번호
+            String accountNumber = accountEntity.getAccountNumber();
+            //일별 누적수익률 리스트
+            List<AccumulatedProfitResponseDto> profits = getAccumulatedProfitResponseDtoList(accountEntity);
+
+            profitAccountInfoResponseDtoList.add(new ProfitAccountInfoResponseDto(aiType, nickname, accountNumber, profits));
+        }
+        return profitAccountInfoResponseDtoList;
+
+    }
+
+    /**
+     * @return 일별 누적수익률 리스트를 반환 -> 오늘총 수익금 / 어제의 총평가 금액 * 100
+     */
+    public List<AccumulatedProfitResponseDto> getAccumulatedProfitResponseDtoList(AccountEntity accountEntity) {
+        List<AccumulatedProfitResponseDto> accumulatedProfitResponseDtoList = new ArrayList<>();
+
+        //계좌의 종목거래내역 List
+        List<TradingDetailEntity> tradingDetailEntityList = accountEntity.getTradingEntities();
+
+        long totalBuyPrice = 0;//총매입금액
+        for (int i = 0; i < tradingDetailEntityList.size(); i++) {
+            //로컬변수 선언
+            TradingDetailEntity currTradingDataEntity = null;//현재의 거래정보 Entity
+            TradingDetailEntity nextTradingDataEntity = null;//다음의 거래정보 Entity
+
+            LocalDateTime currDate = null; //현재의 거리날짜
+            LocalDateTime nextDate = null; //다음의 거래날짜
+
+            //거래정보 Entity를 통해 거래 날짜를 구함
+            currTradingDataEntity = tradingDetailEntityList.get(i);//현재의 거래정보 Entity
+            currDate = currTradingDataEntity.getCreateAt();//현재의 거래 날짜
+            if (i + 1 < tradingDetailEntityList.size()) {
+                nextTradingDataEntity = tradingDetailEntityList.get(i + 1);//다음의 거래정보 Entity
+                nextDate = nextTradingDataEntity.getCreateAt();//다음의 거래 날짜
+                nextDate = LocalDateTime.of(nextDate.getYear(), nextDate.getMonth(), nextDate.getDayOfMonth(), 0, 0, 0);
+            }
+
+            //해당 거래날짜 기준 총매입을 구함
+            totalBuyPrice += currTradingDataEntity.getTradingPrice() * currTradingDataEntity.getTradingAmount();
+
+            //해당 거래날짜 기준으로 다음 거래가 생기기 전 까지의 누적 수익률을 구함
+            LocalDateTime currStartTime = LocalDateTime.of(currDate.getYear(),currDate.getMonth(),currDate.getDayOfMonth(),0,0,0);
+            LocalDateTime currEndTime = LocalDateTime.of(currDate.getYear(),currDate.getMonth(),currDate.getDayOfMonth(),23,59,59);
+            if (nextDate != null) {
+                while (currStartTime.isBefore(nextDate)) {//다음거래 이전까지 누적 수익률을 구해서 리스트에 add함
+                    List<AccountStockDetailEntity> accountStockDetailEntityList = accountStockDetailRepository.findByCreateAtBetweenAndAccount(currStartTime, currEndTime, accountEntity);
+                    if(accountStockDetailEntityList.isEmpty()) break;//
+                    int stockSum = 0;//누적수익금액
+                    //해당일 기준 계좌의 모든 주식의
+                    for (AccountStockDetailEntity accountStockDetailEntity : accountStockDetailEntityList) {
+                        stockSum += accountStockDetailEntity.getAveragePrice() * accountStockDetailEntity.getStockAmount();
+                    }
+                    double currProfit = (double)stockSum / totalBuyPrice * 100;//현재의 누적수익률
+                    accumulatedProfitResponseDtoList.add(new AccumulatedProfitResponseDto(currStartTime, currProfit));
+
+                    //하루증가
+                    currStartTime = currStartTime.plusDays(1);
+                    currEndTime = currEndTime.plusDays(1);
+                }
+            } else {
+                List<AccountStockDetailEntity> accountStockDetailEntityList = accountStockDetailRepository.findByCreateAtBetweenAndAccount(currStartTime, currEndTime, accountEntity);
+                while (!accountStockDetailEntityList.isEmpty()) {//다음거래 이전까지 누적 수익률을 구해서 리스트에 add함
+                    int stockSum = 0;//누적수익금액
+                    //해당일 기준 계좌의 모든 주식의
+                    for (AccountStockDetailEntity accountStockDetailEntity : accountStockDetailEntityList) {
+                        stockSum += accountStockDetailEntity.getAveragePrice() * accountStockDetailEntity.getStockAmount();
+                    }
+                    double currProfit = (double)stockSum / totalBuyPrice * 100;//현재의 누적수익률
+                    accumulatedProfitResponseDtoList.add(new AccumulatedProfitResponseDto(currStartTime, currProfit));
+
+                    //하루증가
+                    currStartTime = currStartTime.plusDays(1);
+                    currEndTime = currEndTime.plusDays(1);
+                    accountStockDetailEntityList = accountStockDetailRepository.findByCreateAtBetweenAndAccount(currStartTime, currEndTime, accountEntity);
+                }
+            }
+
+
+        }
+
+        return accumulatedProfitResponseDtoList;
+
+    }
+
+}


### PR DESCRIPTION
### 구현목록

수익비교 탭 누적수익률 구현했습니다.

### api주소
| 주소 | 메서드 |
| --- | --- |
| `api/profit-compare` | `POST`

### 받는값
~~~json
{
	"customer_info_id" : "1",
	"login_type"       : "00"
}
~~~

### 넘겨주는값
~~~json
{
	"accounts" : [
		{
			"aiType" : "ai번호"
			"nickname" : "계좌이름"
			"accountNumber" : "계좌번호"
			"profits" : [
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
			]
		},
		{
			"aiType" : "ai번호"
			"nickname" : "계좌이름"
			"accountNumber" : "계좌번호"
			"profits" : [
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
				{
					"date"		: "누적수익률 날짜"
					"profit"	: "누적수익률"
				},
			]
		},
	]
}
~~~